### PR TITLE
Rebrand AFRCloud - NET to KILLER - VPN

### DIFF
--- a/converter.html
+++ b/converter.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AFRCloud - NET || Converter</title>
+    <title>KILLER - VPN || Converter</title>
 
     <!-- Favicon -->
-    <link rel="icon" href="https://raw.githubusercontent.com/AFRcloud/BG/main/icons8-film-noir-80.png">
+    <link rel="icon" href="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true">
 
     <!-- Meta tags -->
-    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/akulelaki696/bg/refs/heads/main/20250106_010158.jpg"/>
+    <meta property="og:image:secure_url" content="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true"/>
     <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)"/>
     <meta name="theme-color" content="#f8f9fa" media="(prefers-color-scheme: light)"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="css/common.css">
     <link rel="stylesheet" href="css/converter.css">
     <style>
-    
+
     </style>
 
     <!-- js-yaml for robust YAML parsing -->
@@ -41,7 +41,7 @@
             <div class="tech-detail tech-detail-3"></div>
 
             <div class="title-container">
-                <h1 class="title">AFRCloud - NET</h1>
+                <h1 class="title">KILLER - VPN</h1>
                 <p class="subtitle">V2Ray ↔ Clash Converter</p>
             </div>
 
@@ -135,7 +135,7 @@
                         </div>
                         <textarea id="config-output" class="converter-textarea result-textarea" readonly placeholder="Converted configuration will appear here..."></textarea>
                     </div>
-                </div>	
+                </div>
 				<br>
                 <a href="index.html" class="convert-btn">
                     <i class="fas fa-home"></i> Home
@@ -160,31 +160,31 @@
         <div class="circuit-dot circuit-dot-3"></div>
         <div class="circuit-dot circuit-dot-4"></div>
 
-        <div class="footer-logo">AFRCloud - NET</div>
+        <div class="footer-logo">KILLER - VPN</div>
         <div class="footer-powered">POWERED BY SECURE TECHNOLOGY</div>
         <div class="footer-social">
-            <a href="https://t.me/Noir7R" class="social-link" target="_blank">
+            <a href="https://t.me/Deki_niswara" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-            @Noir7R
-        </a>
-    </div>
+                @Deki_niswara
+            </a>
+        </div>
         <div class="footer-social">
-        <a href="https://t.me/inconigto_Mode" class="social-link" target="_blank">
+        <a href="https://t.me/Dark_System2x" class="social-link" target="_blank">
             <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                 <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
             </svg>
-            @inconigto_Mode
+            @Dark_System2x
         </a>
-        <a href="https://t.me/InconigtoMode" class="social-link" target="_blank">
+        <a href="https://t.me/killervpn_store" class="social-link" target="_blank">
             <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                 <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
             </svg>
-            @InconigtoMode
+            @killervpn_store
         </a>
     </div>
     <div class="footer-year">© <span id="current-year"></span></div></footer>
@@ -206,7 +206,7 @@
                     <i class="fas fa-times"></i>
                 </button>
 
-                <h3 class="donation-title">Support Inconigto-Mode</h3>
+                <h3 class="donation-title">Support KILLER - VPN</h3>
                 <p class="donation-text">Your donation helps keep our services running</p>
 
                 <div class="qris-container">
@@ -226,6 +226,6 @@
     <!-- JavaScript -->
     <script src="js/common.js"></script>
      <script src="js/converter.js"></script>
-   
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AFRCloud - NET || Home</title>
+    <title>KILLER - VPN || Home</title>
     
     <!-- Favicon -->
-    <link rel="icon" href="https://raw.githubusercontent.com/AFRcloud/BG/main/icons8-film-noir-80.png">
+    <link rel="icon" href="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true">
     
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -478,13 +478,13 @@
             <div class="tech-detail tech-detail-3"></div>
             
             <div class="title-container">
-                <h1 class="title">AFRCloud - NET</h1>
+                <h1 class="title">KILLER - VPN</h1>
                 <p class="subtitle">Advanced V2ray Generator</p>
             </div>
             
             
             <div class="profile-container">
-                <img src="https://raw.githubusercontent.com/akulelaki696/bg/refs/heads/main/20250106_010158.jpg" alt="Inconigto Mode Profile" class="profile-img">
+                <img src="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true" alt="KILLER - VPN Profile" class="profile-img">
                 
                 <div class="status-badge">
                     <i class="fas fa-circle"></i> Active Services
@@ -521,9 +521,6 @@
                 <a href="sub" class="action-btn">
                     <i class="fas fa-rss"></i> CREATE SUB V2RAY
                 </a>
-				<a href="https://sub.afrcloud.fun/" class="action-btn">
-                    <i class="fas fa-rss"></i> CREATE SUBLINK V2RAY
-                </a>
 				<a href="converter" class="action-btn">
                     <i class="fas fa-atom"></i> CONVERTER V2RAY TO CLASH
                 </a>
@@ -541,31 +538,29 @@
         <div class="circuit-dot circuit-dot-3"></div>
         <div class="circuit-dot circuit-dot-4"></div>
         
-        <div class="footer-logo">AFRCloud - NET</div>
+        <div class="footer-logo">KILLER - VPN</div>
         <div class="footer-powered">POWERED BY SECURE TECHNOLOGY</div>
         <div class="footer-social">
-            <a href="https://t.me/Noir7R" class="social-link" target="_blank">
+            <a href="https://t.me/Deki_niswara" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @Noir7R
+                @Deki_niswara
             </a>
-        </div>    
-        <div class="footer-social">
-            <a href="https://t.me/inconigto_Mode" class="social-link" target="_blank">
+            <a href="https://t.me/Dark_System2x" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @inconigto_Mode
+                @Dark_System2x
             </a>
-            <a href="https://t.me/InconigtoMode" class="social-link" target="_blank">
+            <a href="https://t.me/killervpn_store" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @InconigtoMode
+                @killervpn_store
             </a>
         </div>
         <div class="footer-year">© <span id="current-year"></span></div>
@@ -589,7 +584,7 @@
                     <i class="fas fa-times"></i>
                 </button>
                 
-                <h3 class="donation-title">Support AFRCloud-NET</h3>
+                <h3 class="donation-title">Support KILLER - VPN</h3>
                 <p class="donation-text">Your donation helps keep our services running</p>
                 
                 <div class="qris-container">

--- a/link.html
+++ b/link.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AFRCloud - NET || Link Generator</title>
+    <title>KILLER - VPN || Link Generator</title>
 
-    <link rel="icon" href="https://raw.githubusercontent.com/AFRcloud/BG/main/icons8-film-noir-80.png">
+    <link rel="icon" href="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true">
 
-    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/akulelaki696/bg/refs/heads/main/20250106_010158.jpg"/>
+    <meta property="og:image:secure_url" content="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true"/>
     <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)"/>
     <meta name="theme-color" content="#f8f9fa" media="(prefers-color-scheme: light)"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -37,7 +37,7 @@
             <div class="tech-detail tech-detail-3"></div>
 
             <div class="title-container">
-                <h1 class="title">AFRCloud - NET</h1>
+                <h1 class="title">KILLER - VPN</h1>
                 <p class="subtitle">Advanced Link Generator</p>
                 <div class="mt-4">
                     <a href="index.html" class="w-full primary-btn py-3 px-4 rounded-lg flex items-center justify-center">
@@ -453,31 +453,29 @@
         <div class="circuit-dot circuit-dot-3"></div>
         <div class="circuit-dot circuit-dot-4"></div>
 
-        <div class="footer-logo">AFRCloud - NET</div>
+        <div class="footer-logo">KILLER - VPN</div>
         <div class="footer-powered">POWERED BY SECURE TECHNOLOGY</div>
         <div class="footer-social">
-            <a href="https://t.me/Noir7R" class="social-link" target="_blank">
+            <a href="https://t.me/Deki_niswara" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @Noir7R
+                @Deki_niswara
             </a>
-        </div>
-        <div class="footer-social">
-            <a href="https://t.me/inconigto_Mode" class="social-link" target="_blank">
+            <a href="https://t.me/Dark_System2x" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @inconigto_Mode
+                @Dark_System2x
             </a>
-            <a href="https://t.me/InconigtoMode" class="social-link" target="_blank">
+            <a href="https://t.me/killervpn_store" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @InconigtoMode
+                @killervpn_store
             </a>
         </div>
         <div class="footer-year">© <span id="current-year"></span></div>
@@ -498,7 +496,7 @@
                     <i class="fas fa-times"></i>
                 </button>
 
-                <h3 class="donation-title">Support AFRCloud - NET</h3>
+                <h3 class="donation-title">Support KILLER - VPN</h3>
                 <p class="donation-text">Your donation helps keep our services running</p>
 
                 <div class="qris-container">

--- a/sub.html
+++ b/sub.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AFRCloud - NET || Subscription</title>
+    <title>KILLER - VPN || Subscription</title>
     
-    <link rel="icon" href="https://raw.githubusercontent.com/AFRcloud/BG/main/icons8-film-noir-80.png"/>
+    <link rel="icon" href="https://github.com/Nizwara/profile/blob/main/profile.png?raw=true"/>
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -30,7 +30,7 @@
             <div class="tech-detail tech-detail-3"></div>
             
             <div class="title-container">
-                <h1 class="title">AFRCloud - NET</h1>
+                <h1 class="title">KILLER - VPN</h1>
                 <p class="subtitle">Advanced Subscription Link Generator</p>
                 <div class="mt-4">
                     <a href="index.html" class="btn">
@@ -165,31 +165,31 @@
         <div class="circuit-dot circuit-dot-3"></div>
         <div class="circuit-dot circuit-dot-4"></div>
         
-        <div class="footer-logo">AFRCloud - NET</div>
+        <div class="footer-logo">KILLER - VPN</div>
         <div class="footer-powered">POWERED BY SECURE TECHNOLOGY</div>
         <div class="footer-social">
-            <a href="https://t.me/Noir7R" class="social-link" target="_blank">
+            <a href="https://t.me/Deki_niswara" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @Noir7R
+                @Deki_niswara
             </a>
         </div>    
         <div class="footer-social">
-            <a href="https://t.me/inconigto_Mode" class="social-link" target="_blank">
+            <a href="https://t.me/Dark_System2x" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @inconigto_Mode
+                @Dark_System2x
             </a>
-            <a href="https://t.me/InconigtoMode" class="social-link" target="_blank">
+            <a href="https://t.me/killervpn_store" class="social-link" target="_blank">
                 <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21.198 2.433a2.242 2.242 0 0 0-1.022.215l-8.609 3.33c-2.068.8-4.133 1.598-5.724 2.21a405.15 405.15 0 0 1-2.849 1.09c-.42.147-.99.332-1.473.901-.728.968.193 1.798.919 2.286 1.61.516 3.275 1.009 4.654 1.472.846 1.467 1.618 2.796 2.503 4.532.545 1.062 1.587 2.739 3.19 2.756 1.26.033 2.052-.6 3.542-1.95a142.91 142.91 0 0 1 2.43-2.053c1.686-.142 3.382-.284 5.12-.436.887-.075 1.92-.262 2.405-1.226.436-.877-.015-1.35-.48-1.874l-3.881-4.369-5.481-6.174S22.185 2.128 21.198 2.433z"></path>
                     <path d="M18.167 7.068c.237 1.632-1.162 6.872-1.766 8.849"></path>
                 </svg>
-                @InconigtoMode
+                @killervpn_store
             </a>
         </div>
         <div class="footer-year">© <span id="current-year"></span></div>
@@ -209,7 +209,7 @@ const CONFIG = {
   proxyListUrl: "ProxyList.txt",
   apiCheckUrl: "https://api.jb8fd7grgd.workers.dev",
   mainDomains: [
-    "afrcloud.fun","afrcloud.web.id"
+    "killervpn.fun","killervpn.web.id"
   ],
   maxProxies: 50,
   defaultProxyCount: 5,
@@ -762,7 +762,7 @@ function generateV2rayLinks(configType, proxies, uuid, bugType, mainDomain, cust
 // Generate Clash configuration
 function generateClashConfig(configType, proxies, uuid, bugType, mainDomain, customBug, useTls) {
   let config = `# Clash Proxy Provider Configuration
-# Generated by Inconigto-Mode
+# Generated by KILLER - VPN
 # Date: ${new Date().toLocaleString("en-US", { timeZone: "Asia/Jakarta" })}
 # Protocol: ${configType.toUpperCase()}
 # TLS: ${useTls ? "Enabled" : "Disabled"}
@@ -933,7 +933,7 @@ proxies:\n`
 }
 
 function generateNekoboxConfig(parsedLinks) {
-  let config = `##INCONIGTO-MODE##
+  let config = `##KILLER-VPN##
 {
   "dns": {
     "final": "dns-final",


### PR DESCRIPTION
This commit rebrands the entire website from "AFRCloud - NET" to "KILLER - VPN".

Changes include:
- Updating all instances of the name "AFRCloud - NET" to "KILLER - VPN".
- Replacing the favicon and profile/og:image with the new KILLER - VPN logo.
- Updating all Telegram contact links to the new accounts.
- Modifying the domain names in the `sub.html` script from `afrcloud.fun` to `killervpn.fun`.
- Removing an obsolete link from `index.html`.